### PR TITLE
Add Storylab planning and rendering modules

### DIFF
--- a/storylab/__init__.py
+++ b/storylab/__init__.py
@@ -1,0 +1,1 @@
+# Storylab package

--- a/storylab/src/__init__.py
+++ b/storylab/src/__init__.py
@@ -1,0 +1,1 @@
+# Storylab source package

--- a/storylab/src/app.py
+++ b/storylab/src/app.py
@@ -1,0 +1,41 @@
+"""FastAPI application providing planning and rendering endpoints."""
+
+from fastapi import FastAPI
+
+from .gpt_planner import GPTPlanner
+from .veo_client import VeoClient
+from .styles import StyleRotator
+from .publisher import Publisher
+from .scheduler import Scheduler
+from . import schemas
+
+app = FastAPI()
+
+_planner = GPTPlanner()
+_renderer = VeoClient()
+_rotator = StyleRotator()
+_publisher = Publisher()
+_scheduler = Scheduler(_planner, _renderer, _rotator, _publisher)
+
+
+@app.post("/plan", response_model=schemas.PlanResponse)
+def plan(req: schemas.PlanRequest) -> schemas.PlanResponse:
+    plan_data = _planner.plan(req.topic)
+    return schemas.PlanResponse(**plan_data)
+
+
+@app.post("/render", response_model=schemas.RenderResponse)
+def render(req: schemas.RenderRequest) -> schemas.RenderResponse:
+    style = req.style or _rotator.get_style()
+    video = _renderer.render(req.plan.dict(), style)
+    return schemas.RenderResponse(**video)
+
+
+@app.post("/run-daily", response_model=schemas.RunDailyResponse)
+def run_daily(req: schemas.RunDailyRequest) -> schemas.RunDailyResponse:
+    result = _scheduler.run_daily(req.topic)
+    return schemas.RunDailyResponse(
+        plan=schemas.PlanData(**result["plan"]),
+        video=schemas.RenderResponse(**result["video"]),
+        publication=result["publication"],
+    )

--- a/storylab/src/gpt_planner.py
+++ b/storylab/src/gpt_planner.py
@@ -1,0 +1,16 @@
+"""GPT-5 planning logic."""
+
+from typing import List, Dict
+
+
+class GPTPlanner:
+    """Simple planner stub emulating GPT-5 logic."""
+
+    def __init__(self, model: str = "gpt-5"):
+        self.model = model
+
+    def plan(self, topic: str) -> Dict[str, List[str]]:
+        """Return a deterministic plan for the given topic."""
+        title = f"Story about {topic}"
+        scenes = [f"{topic} scene {i}" for i in range(1, 4)]
+        return {"title": title, "scenes": scenes}

--- a/storylab/src/publisher.py
+++ b/storylab/src/publisher.py
@@ -1,0 +1,10 @@
+"""Content publisher stub."""
+
+from typing import Dict
+
+
+class Publisher:
+    """Pretend to publish videos to a platform."""
+
+    def publish(self, video: Dict[str, str]) -> str:
+        return f"Published {video.get('video', 'video')}"

--- a/storylab/src/scheduler.py
+++ b/storylab/src/scheduler.py
@@ -1,0 +1,29 @@
+"""Daily scheduler."""
+
+from typing import Dict, List
+
+from .gpt_planner import GPTPlanner
+from .veo_client import VeoClient
+from .styles import StyleRotator
+from .publisher import Publisher
+
+
+class Scheduler:
+    """Coordinate planning, rendering and publishing."""
+
+    def __init__(self,
+                 planner: GPTPlanner,
+                 renderer: VeoClient,
+                 rotator: StyleRotator,
+                 publisher: Publisher):
+        self.planner = planner
+        self.renderer = renderer
+        self.rotator = rotator
+        self.publisher = publisher
+
+    def run_daily(self, topic: str) -> Dict[str, Dict[str, str] | str]:
+        plan = self.planner.plan(topic)
+        style = self.rotator.get_style()
+        video = self.renderer.render(plan, style)
+        publication = self.publisher.publish(video)
+        return {"plan": plan, "video": video, "publication": publication}

--- a/storylab/src/schemas.py
+++ b/storylab/src/schemas.py
@@ -1,0 +1,39 @@
+"""Pydantic schemas for the API."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+
+class PlanRequest(BaseModel):
+    topic: str
+
+
+class PlanData(BaseModel):
+    title: str
+    scenes: List[str]
+
+
+class RenderRequest(BaseModel):
+    plan: PlanData
+    style: str | None = None
+
+
+class RenderResponse(BaseModel):
+    video: str
+
+
+class PlanResponse(PlanData):
+    pass
+
+
+class RunDailyRequest(BaseModel):
+    topic: str
+
+
+class RunDailyResponse(BaseModel):
+    plan: PlanData
+    video: RenderResponse
+    publication: str

--- a/storylab/src/selenium_portal.py
+++ b/storylab/src/selenium_portal.py
@@ -1,0 +1,8 @@
+"""Selenium portal automation stub."""
+
+
+class SeleniumPortal:
+    """Simple stub representing a selenium automation client."""
+
+    def open(self, url: str) -> str:
+        return f"Opened {url}"

--- a/storylab/src/styles.py
+++ b/storylab/src/styles.py
@@ -1,0 +1,16 @@
+"""Style rotation utilities."""
+
+from typing import List
+
+
+class StyleRotator:
+    """Rotate through a list of visual styles."""
+
+    def __init__(self, styles: List[str] | None = None):
+        self.styles = styles or ["cinematic", "comic", "watercolor"]
+        self._index = 0
+
+    def get_style(self) -> str:
+        style = self.styles[self._index]
+        self._index = (self._index + 1) % len(self.styles)
+        return style

--- a/storylab/src/veo_client.py
+++ b/storylab/src/veo_client.py
@@ -1,0 +1,14 @@
+"""Veo-3 rendering client stub."""
+
+from typing import Dict, List
+
+
+class VeoClient:
+    """Client that renders a plan into a video."""
+
+    def __init__(self, model: str = "veo-3"):
+        self.model = model
+
+    def render(self, plan: Dict[str, List[str]], style: str) -> Dict[str, str]:
+        title = plan.get("title", "untitled")
+        return {"video": f"Rendered {title} in {style} style"}

--- a/storylab/tests/__init__.py
+++ b/storylab/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/storylab/tests/test_planner.py
+++ b/storylab/tests/test_planner.py
@@ -1,0 +1,9 @@
+from storylab.src.gpt_planner import GPTPlanner
+
+
+def test_plan_contains_title_and_scenes():
+    planner = GPTPlanner()
+    plan = planner.plan("cats")
+    assert plan["title"] == "Story about cats"
+    assert plan["scenes"][0] == "cats scene 1"
+    assert len(plan["scenes"]) == 3

--- a/storylab/tests/test_styles.py
+++ b/storylab/tests/test_styles.py
@@ -1,0 +1,8 @@
+from storylab.src.styles import StyleRotator
+
+
+def test_style_rotation_cycles_through_styles():
+    rotator = StyleRotator(["a", "b"])
+    assert rotator.get_style() == "a"
+    assert rotator.get_style() == "b"
+    assert rotator.get_style() == "a"


### PR DESCRIPTION
## Summary
- add FastAPI app with /plan, /render and /run-daily endpoints
- include GPT-5 planner, Veo-3 renderer, style rotation and scheduler utilities
- provide tests for planning and style rotation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b21430e37883288fc598a93293d5de