### PR TITLE
Add configuration loader and environment sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# Environment configuration for AlphaSigma
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_MODEL_ID=your-openai-model-id
+GCP_API_KEY=your-gcp-api-key
+GCP_MODEL_ID=your-gcp-model-id
+TIMEZONE=UTC

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # AlphaSigma
 Video generation maybe
+
+## Configuration
+
+1. Copy `.env.sample` to `.env` and fill in the required values.
+2. Add your OpenAI and Google Cloud API keys.
+3. Specify the model IDs and timezone.
+
+`.env` is ignored by git, so your secrets stay local.

--- a/storylab/src/config.py
+++ b/storylab/src/config.py
@@ -1,0 +1,77 @@
+"""Load configuration from environment variables."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+REQUIRED_KEYS = [
+    "OPENAI_API_KEY",
+    "OPENAI_MODEL_ID",
+    "GCP_API_KEY",
+    "GCP_MODEL_ID",
+    "TIMEZONE",
+]
+
+
+def _ensure_no_env_committed(root: Path) -> None:
+    """Raise an error if a tracked `.env` file exists."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", ".env"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return
+    if result.stdout.strip():
+        raise RuntimeError(
+            ".env file is committed to git; remove it and use .env.sample"
+        )
+
+
+def _load_env_file(env_path: Path) -> None:
+    """Populate ``os.environ`` with values from an ``.env`` file."""
+    if not env_path.exists():
+        return
+    with env_path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key, value)
+
+
+def load_config() -> Dict[str, str]:
+    """Return required configuration values.
+
+    Loads variables from a local ``.env`` file if present and ensures they
+    exist in the environment. Raises ``RuntimeError`` if any required key is
+    missing or if a ``.env`` file has been committed to git.
+    """
+
+    root = Path(__file__).resolve().parents[2]
+    env_file = root / ".env"
+
+    _load_env_file(env_file)
+    _ensure_no_env_committed(root)
+
+    config = {}
+    missing = []
+    for key in REQUIRED_KEYS:
+        value = os.getenv(key)
+        if value:
+            config[key] = value
+        else:
+            missing.append(key)
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+    return config

--- a/storylab/tests/test_config.py
+++ b/storylab/tests/test_config.py
@@ -1,0 +1,26 @@
+import pytest
+
+from storylab.src import config
+
+
+def test_missing_keys_raise_error(monkeypatch):
+    for key in config.REQUIRED_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(RuntimeError):
+        config.load_config()
+
+
+def test_load_config_success(monkeypatch):
+    # ensure all required keys exist
+    values = {
+        "OPENAI_API_KEY": "openai",
+        "OPENAI_MODEL_ID": "gpt-4",
+        "GCP_API_KEY": "gcp",
+        "GCP_MODEL_ID": "gpt",
+        "TIMEZONE": "UTC",
+    }
+    for k, v in values.items():
+        monkeypatch.setenv(k, v)
+
+    cfg = config.load_config()
+    assert cfg == values


### PR DESCRIPTION
## Summary
- Provide `.env.sample` template for OpenAI and GCP credentials, model IDs, and timezone
- Document environment setup in README and confirm `.env` is git-ignored
- Implement config loader that prevents committing `.env` and validates required keys
- Add tests covering config loader behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2152d53e4832890eed624ff6f5001