### PR TITLE
Add Docker setup with Selenium Chrome service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+EXPOSE 8000
+
+CMD ["uvicorn", "storylab.src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Video generation maybe
 3. Specify the model IDs and timezone.
 
 `.env` is ignored by git, so your secrets stay local.
+
+## Docker
+
+Build and start the API with a Selenium Chrome container:
+
+```bash
+docker compose up -d --build
+```
+
+The API will be available on http://localhost:8000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - chrome
+  chrome:
+    image: selenium/standalone-chrome
+    ports:
+      - "4444:4444"
+      - "7900:7900"
+    volumes:
+      - chrome-data:/home/seluser/.config/google-chrome
+
+volumes:
+  chrome-data:


### PR DESCRIPTION
## Summary
- Provide Dockerfile based on python:3.11-slim installing FastAPI and Uvicorn
- Add docker-compose.yml to run API with Selenium Chrome service and persistent profile volume
- Document docker compose usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b217e333c083289b23eccbe98e97f6