### PR TITLE
Add CI workflow for linting, tests, and daily trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure no .env file is committed
+        run: |
+          if git ls-files | grep -E '(^|/).env$'; then
+            echo '.env file found. Please remove it.' >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest
+
+  run-daily:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger daily run
+        env:
+          RUN_DAILY_URL: ${{ secrets.RUN_DAILY_URL }}
+        run: |
+          if [ -z "$RUN_DAILY_URL" ]; then
+            echo 'RUN_DAILY_URL secret not set; skipping.'
+            exit 0
+          fi
+          curl -X POST "$RUN_DAILY_URL"


### PR DESCRIPTION
## Summary
- add CI workflow to run ruff and pytest
- fail if `.env` is committed
- schedule optional daily trigger for `/run-daily`

## Testing
- `ruff check storylab` (fails: `typing.List` imported but unused)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21fa4702483288124b6a2a17fa36a