### PR TITLE
Add deterministic style selection and planner schema tests

### DIFF
--- a/storylab/src/gpt_planner.py
+++ b/storylab/src/gpt_planner.py
@@ -1,16 +1,64 @@
-"""GPT-5 planning logic."""
+"""GPT planning logic using the OpenAI responses API."""
 
-from typing import List, Dict
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover
+    OpenAI = None  # type: ignore
+
+# JSON schema used for structured output from the model.
+PLAN_SCHEMA = {
+    "name": "plan",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "scenes": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+            },
+        },
+        "required": ["title", "scenes"],
+        "additionalProperties": False,
+    },
+}
 
 
 class GPTPlanner:
-    """Simple planner stub emulating GPT-5 logic."""
+    """Planner that requests a structured story plan from GPT."""
 
-    def __init__(self, model: str = "gpt-5"):
+    def __init__(self, model: str = "gpt-5", client: Any | None = None):
         self.model = model
+        if client is not None:
+            self.client = client
+        else:
+            if OpenAI is None:
+                raise RuntimeError("openai package is required when no client is provided")
+            self.client = OpenAI()
 
-    def plan(self, topic: str) -> Dict[str, List[str]]:
-        """Return a deterministic plan for the given topic."""
-        title = f"Story about {topic}"
-        scenes = [f"{topic} scene {i}" for i in range(1, 4)]
-        return {"title": title, "scenes": scenes}
+    def plan(self, topic: str, style: str | None = None) -> Dict[str, List[str]]:
+        """Return a plan for the given topic.
+
+        Parameters
+        ----------
+        topic:
+            The subject to plan a story about.
+        style:
+            Optional visual style hint that is forwarded as a custom HTTP
+            header to the API.
+        """
+
+        headers = {"style": style} if style else None
+        resp = self.client.responses.create(
+            model=self.model,
+            input=[{"role": "user", "content": [{"type": "text", "text": topic}]}],
+            response_format={"type": "json_schema", "json_schema": PLAN_SCHEMA},
+            extra_headers=headers,
+        )
+        raw = resp.output[0].content[0].text
+        return json.loads(raw)

--- a/storylab/src/scheduler.py
+++ b/storylab/src/scheduler.py
@@ -1,6 +1,6 @@
 """Daily scheduler."""
 
-from typing import Dict, List
+from typing import Dict
 
 from .gpt_planner import GPTPlanner
 from .veo_client import VeoClient

--- a/storylab/src/styles.py
+++ b/storylab/src/styles.py
@@ -1,5 +1,6 @@
 """Style rotation utilities."""
 
+from datetime import date
 from typing import List
 
 
@@ -14,3 +15,14 @@ class StyleRotator:
         style = self.styles[self._index]
         self._index = (self._index + 1) % len(self.styles)
         return style
+
+    def style_for_date(self, day: date) -> str:
+        """Return a deterministic style for the given date.
+
+        The selection cycles through the available styles based on the
+        ordinal value of ``day``. This ensures the same style is returned for
+        the same date and that styles rotate daily.
+        """
+
+        index = day.toordinal() % len(self.styles)
+        return self.styles[index]

--- a/storylab/tests/test_planner.py
+++ b/storylab/tests/test_planner.py
@@ -1,9 +1,24 @@
-from storylab.src.gpt_planner import GPTPlanner
+import json
+from types import SimpleNamespace
+
+from storylab.src.gpt_planner import GPTPlanner, PLAN_SCHEMA
 
 
-def test_plan_contains_title_and_scenes():
-    planner = GPTPlanner()
-    plan = planner.plan("cats")
-    assert plan["title"] == "Story about cats"
-    assert plan["scenes"][0] == "cats scene 1"
-    assert len(plan["scenes"]) == 3
+def test_plan_uses_json_schema_and_style_header():
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        data = {"title": "Story about cats", "scenes": ["a", "b"]}
+        return SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(data))])]
+        )
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    planner = GPTPlanner(client=fake_client, model="test-model")
+
+    plan = planner.plan("cats", style="comic")
+
+    assert plan == {"title": "Story about cats", "scenes": ["a", "b"]}
+    assert captured["response_format"]["json_schema"] == PLAN_SCHEMA
+    assert captured["extra_headers"] == {"style": "comic"}

--- a/storylab/tests/test_styles.py
+++ b/storylab/tests/test_styles.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 from storylab.src.styles import StyleRotator
 
 
@@ -6,3 +8,16 @@ def test_style_rotation_cycles_through_styles():
     assert rotator.get_style() == "a"
     assert rotator.get_style() == "b"
     assert rotator.get_style() == "a"
+
+
+def test_style_selection_deterministic_per_date():
+    rotator = StyleRotator(["a", "b", "c"])
+    day = date(2024, 1, 1)
+    # Repeated calls with same date yield the same style
+    first = rotator.style_for_date(day)
+    second = rotator.style_for_date(day)
+    assert first == second
+
+    # Dates separated by multiples of the number of styles map to same style
+    repeat_day = day + timedelta(days=len(rotator.styles))
+    assert rotator.style_for_date(repeat_day) == first


### PR DESCRIPTION
## Summary
- Add `style_for_date` to `StyleRotator` for deterministic daily style selection
- Implement `GPTPlanner` using OpenAI Responses API with JSON schema and style header
- Add tests for style rotation and planner request formatting
- Clean up scheduler imports

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b31cf238108328a381b275f77cd940