### PR TITLE
Document prompt guidelines

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,14 @@
+# Prompt Guidelines
+
+## Style Header
+
+When generating a story plan or rendering a video, include the desired visual style as a `style` HTTP header. The planner forwards this header to the model so output reflects the chosen aesthetic.
+
+## Telephoto and Anamorphic Constraints
+
+Maintain a neutral, cinematic look by avoiding extreme telephoto compression or anamorphic distortion. Keep focal lengths in a standard range and do not request anamorphic lenses unless absolutely required.
+
+## Dialogue Guidance
+
+Write dialogue in concise, natural lines. Prefix each line with the speaker's name followed by a colon and limit individual quotes to one or two sentences to preserve pacing.
+

--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ curl -X POST http://localhost:8000/run-daily \
 
 In production, call this endpoint from a cron job or other scheduler to run
 the workflow daily.
+
+## Maintainers
+
+See [PROMPT.md](PROMPT.md) for guidance on style headers, lens constraints, and dialogue conventions.
+


### PR DESCRIPTION
## Summary
- add PROMPT.md outlining style header usage, lens constraints, and dialogue formatting
- mention prompt guidance in README so maintainers can find it easily

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b31ed5fa988328a3ecf1fcc09cfac9