### PR TITLE
feat: log rendered URIs via placeholder publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ curl -X POST http://localhost:8000/run-daily \
 In production, call this endpoint from a cron job or other scheduler to run
 the workflow daily.
 
+## Publishing and Extensions
+
+`Publisher` currently logs the URI of each rendered video. Extend this class to
+support additional destinations:
+
+- Social platforms such as YouTube, TikTok or Instagram.
+- Storage services like Amazon S3 or Google Cloud Storage.
+
+Custom implementations can authenticate with external services, upload the
+rendered asset and return a link or identifier.
+
 ## Maintainers
 
 See [PROMPT.md](PROMPT.md) for guidance on style headers, lens constraints, and dialogue conventions.

--- a/storylab/src/publisher.py
+++ b/storylab/src/publisher.py
@@ -1,10 +1,41 @@
-"""Content publisher stub."""
+"""Content publisher placeholder.
 
+This module logs the URI of a rendered video rather than publishing it to an
+external service.  The :class:`Publisher` class is intentionally lightweight so
+that it can be extended to support integrations with social platforms or
+storage services.
+"""
+
+from __future__ import annotations
+
+import logging
 from typing import Dict
+
+logger = logging.getLogger(__name__)
 
 
 class Publisher:
-    """Pretend to publish videos to a platform."""
+    """Placeholder publisher that only logs video URIs.
+
+    Subclass this class to push videos to destinations such as YouTube, TikTok
+    or cloud object stores.  The default implementation simply records the URI
+    of a rendered video for observability during development.
+    """
 
     def publish(self, video: Dict[str, str]) -> str:
-        return f"Published {video.get('video', 'video')}"
+        """Log the video's URI and return it.
+
+        Args:
+            video: Mapping containing details about the rendered video. It is
+                expected to provide a ``uri`` field identifying the location of
+                the rendered asset.  A ``video`` key is used as a fallback for
+                tests where a URI is not supplied.
+
+        Returns:
+            The URI that would be published.
+        """
+
+        uri = video.get("uri") or video.get("video", "")
+        logger.info("Publishing video %s", uri)
+        return uri
+

--- a/storylab/tests/test_publisher.py
+++ b/storylab/tests/test_publisher.py
@@ -1,0 +1,17 @@
+"""Tests for the publisher module."""
+
+import logging
+
+from storylab.src.publisher import Publisher
+
+
+def test_publish_logs_uri(caplog):
+    publisher = Publisher()
+    video = {"uri": "https://example.com/video.mp4"}
+
+    with caplog.at_level(logging.INFO):
+        uri = publisher.publish(video)
+
+    assert uri == video["uri"]
+    assert video["uri"] in caplog.text
+


### PR DESCRIPTION
## Summary
- implement stub publisher that logs rendered video URIs
- document how Publisher can be extended to social platforms or storage
- add tests for logging behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b320630c108328899e2128bd338c04